### PR TITLE
Word-align the address of polymul_asm

### DIFF
--- a/generate-multiplications.py
+++ b/generate-multiplications.py
@@ -915,10 +915,10 @@ if __name__ == '__main__':
         for statement in postprocess_karatsuba(fn_gen):
           p(statement)
 
-    p(f".global polymul_asm")
-    p(f".type polymul_asm, %function")
-
-    p(f"polymul_asm:")
+    p(".global polymul_asm")
+    p(".type polymul_asm, %function")
+    p(".align 2")
+    p("polymul_asm:")
     p("push {r4-r12, r14}")
 
     for statement in outermult:


### PR DESCRIPTION
For the m4-optimized implementation of Kindi in pqm4, this saved on the order of 20k-30k cycles for keygen, encapsulation, and decapsulation. I have not benchmarked the rest yet, but I guess you'd always want to word-align this.